### PR TITLE
Fix stray semicolons in registry commands

### DIFF
--- a/src/commands/registry/delete.ts
+++ b/src/commands/registry/delete.ts
@@ -23,7 +23,7 @@ export default class RegistryDelete extends SfCommand<void> {
       },
     ]);
 
-    const resultFetchCatalog = await fetchCatalog(server);;
+    const resultFetchCatalog = await fetchCatalog(server);
     if (!resultFetchCatalog.ok) {
       this.error(`Erreur lors de la récupération du catalogue : ${resultFetchCatalog.error}`);
     }

--- a/src/commands/registry/download.ts
+++ b/src/commands/registry/download.ts
@@ -29,7 +29,7 @@ export default class RegistryDownload extends SfCommand<void> {
       },
     ]);
 
-   const resultFetchCatalog = await fetchCatalog(server);;
+   const resultFetchCatalog = await fetchCatalog(server);
   if (!resultFetchCatalog.ok) {
     this.error(`Erreur lors de la récupération du catalogue : ${resultFetchCatalog.error}`);
   }

--- a/src/commands/registry/list.ts
+++ b/src/commands/registry/list.ts
@@ -22,7 +22,7 @@ export default class RegistryList extends SfCommand<void> {
       },
     ]);
 
-    const resultFetchCatalog = await fetchCatalog(server);;
+    const resultFetchCatalog = await fetchCatalog(server);
     if (!resultFetchCatalog.ok) {
       this.error(`Erreur lors de la récupération du catalogue : ${resultFetchCatalog.error}`);
     }


### PR DESCRIPTION
## Summary
- remove stray semicolons when fetching catalog

## Testing
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683ff09248a88328a1657841b8435916